### PR TITLE
Add comment about vendoring in OCP fork.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ Vagrantfile
 *.swp
 
 # go
+
+# Upstream does not have vendor checked in, but we need it downstream.
 #vendor/
 
 # IntelliJ


### PR DESCRIPTION
Upstream does not have vendor/ checked into their repository, but we need
it in OCP. Add a comment about that.

