### PR TITLE
carry: Fix binary location source

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -4,5 +4,5 @@ COPY . .
 RUN make
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
-COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver /usr/bin/
+COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /usr/bin/
 ENTRYPOINT ["/usr/bin/aws-ebs-csi-driver"]

--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -4,5 +4,5 @@ COPY . .
 RUN make
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
-COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/aws-ebs-csi-driver /usr/bin/
+COPY --from=builder /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver/bin/aws-ebs-csi-driver /usr/bin/
 ENTRYPOINT ["/usr/bin/aws-ebs-csi-driver"]


### PR DESCRIPTION
Fixes this error when starting driver pods:

`Error: container create failed: time="2020-04-03T08:51:26Z" level=error msg="container_linux.go:349: starting container process caused \"exec: \\\"/usr/bin/aws-ebs-csi-driver\\\": stat /usr/bin/aws-ebs-csi-driver: no such file or directory\""`