### PR TITLE
Bug 1872251: Upstream: 555: Vendor deps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,7 @@
 
 FROM golang:1.14.1-stretch as builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
-
-# Cache go modules
-COPY go.mod .
-COPY go.sum .
-RUN go mod download
-
-ADD . .
+COPY . .
 RUN make
 
 FROM amazonlinux:2

--- a/Makefile
+++ b/Makefile
@@ -23,17 +23,6 @@ GOPROXY=direct
 GOPATH=$(shell go env GOPATH)
 GOOS=$(shell go env GOOS)
 GOBIN=$(shell pwd)/bin
-GO ?=go
-deps_diff := diff --no-dereference -N
-
-# $1 - temporary directory
-define restore-deps
-	ln -s $(abspath ./) "$(1)"/current
-	cp -R -H ./ "$(1)"/updated
-	rm -rf "$(1)"/updated/vendor
-	cd "$(1)"/updated && $(GO) mod vendor && $(GO) mod tidy && $(GO) mod verify
-	cd "$(1)" && $(deps_diff) -r {current,updated}/vendor/ > updated/deps.diff || true
-endef
 
 .EXPORT_ALL_VARIABLES:
 
@@ -73,20 +62,6 @@ verify: bin/golangci-lint
 	echo "verifying and linting files ..."
 	./hack/verify-all
 	echo "Congratulations! All Go source files have been linted."
-
-.PHONY: verify-deps
-verify-deps: tmp_dir:=$(shell mktemp -d)
-verify-deps:
-	$(call restore-deps,$(tmp_dir))
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.mod || ( echo '`go.mod` content is incorrect - did you run `go mod tidy`?' && false )
-	$(deps_diff) "$(tmp_dir)"/{current,updated}/go.sum || ( echo '`go.sum` content is incorrect - did you run `go mod tidy`?' && false )
-	@echo $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff
-	@     $(deps_diff) '$(tmp_dir)'/{current,updated}/deps.diff || ( \
-		echo "ERROR: Content of 'vendor/' directory doesn't match 'go.mod' configuration and the overrides in 'deps.diff'!" && \
-		echo 'Did you run `go mod vendor`?' && \
-		echo "If this is an intentional change (a carry patch) please update the 'deps.diff' using 'make update-deps-overrides'." && \
-		false \
-	)
 
 .PHONY: test
 test:

--- a/Makefile
+++ b/Makefile
@@ -130,10 +130,10 @@ push-release:
 push:
 	docker push $(IMAGE):latest
 
-.PHONY: test-vendor
-test: test-vendor
-verify: test-vendor
-test-vendor:
+.PHONY: verify-vendor
+test: verify-vendor
+verify: verify-vendor
+verify-vendor:
 	@ echo; echo "### $@:"
 	@ ./hack/verify-vendor.sh
 

--- a/Makefile
+++ b/Makefile
@@ -70,8 +70,8 @@ mockgen: bin/mockgen
 
 .PHONY: verify
 verify: bin/golangci-lint
-	echo "Running golangci-lint..."
-	./bin/golangci-lint run --deadline=10m
+	echo "verifying and linting files ..."
+	./hack/verify-all
 	echo "Congratulations! All Go source files have been linted."
 
 .PHONY: verify-deps

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ endef
 
 .EXPORT_ALL_VARIABLES:
 
+.PHONY: bin/aws-ebs-csi-driver
 bin/aws-ebs-csi-driver: | bin
 	CGO_ENABLED=0 GOOS=linux go build -ldflags ${LDFLAGS} -o bin/aws-ebs-csi-driver ./cmd/
 
@@ -128,6 +129,14 @@ push-release:
 .PHONY: push
 push:
 	docker push $(IMAGE):latest
+
+.PHONY: test-vendor
+test: test-vendor
+verify: test-vendor
+test-vendor:
+	@ echo; echo "### $@:"
+	@ ./hack/verify-vendor.sh
+
 
 .PHONY: generate-kustomize
 generate-kustomize: bin/helm

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,8 @@ push:
 test: verify-vendor
 verify: verify-vendor
 verify-vendor:
+	echo "go:" `go version`
+	echo "git:" `git version`
 	@ echo; echo "### $@:"
 	@ ./hack/verify-vendor.sh
 

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endef
 
 .PHONY: bin/aws-ebs-csi-driver
 bin/aws-ebs-csi-driver: | bin
-	CGO_ENABLED=0 GOOS=linux go build -ldflags ${LDFLAGS} -o bin/aws-ebs-csi-driver ./cmd/
+	CGO_ENABLED=0 GOOS=linux go build -mod=vendor -ldflags ${LDFLAGS} -o bin/aws-ebs-csi-driver ./cmd/
 
 bin /tmp/helm /tmp/kubeval:
 	@mkdir -p $@

--- a/hack/verify-all
+++ b/hack/verify-all
@@ -20,4 +20,5 @@ PKG_ROOT=$(git rev-parse --show-toplevel)
 
 ${PKG_ROOT}/hack/verify-gofmt
 ${PKG_ROOT}/hack/verify-govet
+${PKG_ROOT}/bin/golangci-lint run --deadline=10m
 ${PKG_ROOT}/hack/verify-vendor.sh

--- a/hack/verify-all
+++ b/hack/verify-all
@@ -20,4 +20,4 @@ PKG_ROOT=$(git rev-parse --show-toplevel)
 
 ${PKG_ROOT}/hack/verify-gofmt
 ${PKG_ROOT}/hack/verify-govet
-${PKG_ROOT}/hack/verify-golint
+${PKG_ROOT}/hack/verify-vendor.sh

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -14,47 +14,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if [ -f Gopkg.toml ]; then
-    echo "Repo uses 'dep' for vendoring."
-    case "$(dep version 2>/dev/null | grep 'version *:')" in
-        *v0.[56789]*)
-            if dep check; then
-                echo "vendor up-to-date"
-            else
-                exit 1
-            fi
-            ;;
-        *) echo "skipping check, dep >= 0.5 required";;
-    esac
-elif [ -f go.mod ]; then
-    echo "Repo uses 'go mod'."
-    # shellcheck disable=SC2235
-    if [ "${JOB_NAME}" ] &&
-           ( [ "${JOB_TYPE}" != "presubmit" ] ||
-                 [ "$( (git diff "${PULL_BASE_SHA}..HEAD" -- go.mod go.sum vendor release-tools;
-                        git diff "${PULL_BASE_SHA}..HEAD" | grep -e '^@@.*@@ import (' -e '^[+-]import') |
-		           wc -l)" -eq 0 ] ); then
-	echo "Skipping vendor check because the Prow pre-submit job does not affect dependencies."
-    elif ! (set -x; env GO111MODULE=on go mod tidy); then
+
+echo "Repo uses 'go mod'."
+if ! (set -x; env GO111MODULE=on go mod tidy); then
+    echo "ERROR: vendor check failed."
+    exit 1
+elif [ "$(git status --porcelain -- go.mod go.sum | wc -l)" -gt 0 ]; then
+    echo "ERROR: go module files *not* up-to-date, they did get modified by 'GO111MODULE=on go mod tidy':";
+    git diff -- go.mod go.sum
+    exit 1
+elif [ -d vendor ]; then
+    if ! (set -x; env GO111MODULE=on go mod vendor); then
 	echo "ERROR: vendor check failed."
 	exit 1
-    elif [ "$(git status --porcelain -- go.mod go.sum | wc -l)" -gt 0 ]; then
-	echo "ERROR: go module files *not* up-to-date, they did get modified by 'GO111MODULE=on go mod tidy':";
-	git diff -- go.mod go.sum
+    elif [ "$(git status --porcelain -- vendor | wc -l)" -gt 0 ]; then
+	echo "ERROR: vendor directory *not* up-to-date, it did get modified by 'GO111MODULE=on go mod vendor':"
+	git status -- vendor
+	git diff -- vendor
 	exit 1
-    elif [ -d vendor ]; then
-	if ! (set -x; env GO111MODULE=on go mod vendor); then
-	    echo "ERROR: vendor check failed."
-	    exit 1
-	elif [ "$(git status --porcelain -- vendor | wc -l)" -gt 0 ]; then
-	    echo "ERROR: vendor directory *not* up-to-date, it did get modified by 'GO111MODULE=on go mod vendor':"
-	    git status -- vendor
-	    git diff -- vendor
-	    exit 1
-	else
-	    echo "Go dependencies and vendor directory up-to-date."
-	fi
     else
-	echo "Go dependencies up-to-date."
+	echo "Go dependencies and vendor directory up-to-date."
     fi
+else
+    echo "Go dependencies up-to-date."
 fi

--- a/hack/verify-vendor.sh
+++ b/hack/verify-vendor.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if [ -f Gopkg.toml ]; then
+    echo "Repo uses 'dep' for vendoring."
+    case "$(dep version 2>/dev/null | grep 'version *:')" in
+        *v0.[56789]*)
+            if dep check; then
+                echo "vendor up-to-date"
+            else
+                exit 1
+            fi
+            ;;
+        *) echo "skipping check, dep >= 0.5 required";;
+    esac
+elif [ -f go.mod ]; then
+    echo "Repo uses 'go mod'."
+    # shellcheck disable=SC2235
+    if [ "${JOB_NAME}" ] &&
+           ( [ "${JOB_TYPE}" != "presubmit" ] ||
+                 [ "$( (git diff "${PULL_BASE_SHA}..HEAD" -- go.mod go.sum vendor release-tools;
+                        git diff "${PULL_BASE_SHA}..HEAD" | grep -e '^@@.*@@ import (' -e '^[+-]import') |
+		           wc -l)" -eq 0 ] ); then
+	echo "Skipping vendor check because the Prow pre-submit job does not affect dependencies."
+    elif ! (set -x; env GO111MODULE=on go mod tidy); then
+	echo "ERROR: vendor check failed."
+	exit 1
+    elif [ "$(git status --porcelain -- go.mod go.sum | wc -l)" -gt 0 ]; then
+	echo "ERROR: go module files *not* up-to-date, they did get modified by 'GO111MODULE=on go mod tidy':";
+	git diff -- go.mod go.sum
+	exit 1
+    elif [ -d vendor ]; then
+	if ! (set -x; env GO111MODULE=on go mod vendor); then
+	    echo "ERROR: vendor check failed."
+	    exit 1
+	elif [ "$(git status --porcelain -- vendor | wc -l)" -gt 0 ]; then
+	    echo "ERROR: vendor directory *not* up-to-date, it did get modified by 'GO111MODULE=on go mod vendor':"
+	    git status -- vendor
+	    git diff -- vendor
+	    exit 1
+	else
+	    echo "Go dependencies and vendor directory up-to-date."
+	fi
+    else
+	echo "Go dependencies up-to-date."
+    fi
+fi


### PR DESCRIPTION
**What is this PR about? / Why do we need it?**
Backports most of https://github.com/kubernetes-sigs/aws-ebs-csi-driver/pull/555/.  I couldn't pull this down as a single patch (due to all of the vendor changes), but I cherry-pick'd most of the individual commits and then removed the previous `verify-deps` job from the Makefile in a separate commit.

**What testing is done?** 
 Confirmed the `make verify-vendor` and `make verify` jobs ran without failure.