### PR TITLE
Bug 1876935: UPSTREAM: 568: Apply extra volume tags to EBS snapshots

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -30,6 +30,7 @@ func main() {
 
 	drv, err := driver.NewDriver(
 		driver.WithEndpoint(options.ServerOptions.Endpoint),
+		driver.WithExtraTags(options.ControllerOptions.ExtraTags),
 		driver.WithExtraVolumeTags(options.ControllerOptions.ExtraVolumeTags),
 		driver.WithMode(options.DriverMode),
 		driver.WithVolumeAttachLimit(options.NodeOptions.VolumeAttachLimit),

--- a/cmd/options/controller_options.go
+++ b/cmd/options/controller_options.go
@@ -24,15 +24,19 @@ import (
 
 // ControllerOptions contains options and configuration settings for the controller service.
 type ControllerOptions struct {
+	// ExtraTags is a map of tags that will be attached to each dynamically provisioned
+	// resource.
+	ExtraTags map[string]string
 	// ExtraVolumeTags is a map of tags that will be attached to each dynamically provisioned
 	// volume.
+	// DEPRECATED: Use ExtraTags instead.
 	ExtraVolumeTags map[string]string
-	// ID of the kubernetes cluster. This is used only to create the same tags on volumes that
-	// in-tree volume volume plugin does.
+	// ID of the kubernetes cluster.
 	KubernetesClusterID string
 }
 
 func (s *ControllerOptions) AddFlags(fs *flag.FlagSet) {
-	fs.Var(cliflag.NewMapStringString(&s.ExtraVolumeTags), "extra-volume-tags", "Extra volume tags to attach to each dynamically provisioned volume. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
+	fs.Var(cliflag.NewMapStringString(&s.ExtraTags), "extra-tags", "Extra tags to attach to each dynamically provisioned resource. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
+	fs.Var(cliflag.NewMapStringString(&s.ExtraVolumeTags), "extra-volume-tags", "DEPRECATED: Please use --extra-tags instead. Extra volume tags to attach to each dynamically provisioned volume. It is a comma separated list of key value pairs like '<key1>=<value1>,<key2>=<value2>'")
 	fs.StringVar(&s.KubernetesClusterID, "k8s-tag-cluster-id", "", "ID of the Kubernetes cluster used for tagging provisioned EBS volumes (optional).")
 }

--- a/cmd/options_test.go
+++ b/cmd/options_test.go
@@ -39,11 +39,11 @@ func TestGetOptions(t *testing.T) {
 		endpointFlagName := "endpoint"
 		endpoint := "foo"
 
-		extraVolumeTagsFlagName := "extra-volume-tags"
-		extraVolumeTagKey := "bar"
-		extraVolumeTagValue := "baz"
-		extraVolumeTags := map[string]string{
-			extraVolumeTagKey: extraVolumeTagValue,
+		extraTagsFlagName := "extra-tags"
+		extraTagKey := "bar"
+		extraTagValue := "baz"
+		extraTags := map[string]string{
+			extraTagKey: extraTagValue,
 		}
 
 		VolumeAttachLimitFlagName := "volume-attach-limit"
@@ -57,7 +57,7 @@ func TestGetOptions(t *testing.T) {
 			args = append(args, "-"+endpointFlagName+"="+endpoint)
 		}
 		if withControllerOptions {
-			args = append(args, "-"+extraVolumeTagsFlagName+"="+extraVolumeTagKey+"="+extraVolumeTagValue)
+			args = append(args, "-"+extraTagsFlagName+"="+extraTagKey+"="+extraTagValue)
 		}
 		if withNodeOptions {
 			args = append(args, "-"+VolumeAttachLimitFlagName+"="+strconv.FormatInt(VolumeAttachLimit, 10))
@@ -80,12 +80,12 @@ func TestGetOptions(t *testing.T) {
 		}
 
 		if withControllerOptions {
-			extraVolumeTagsFlag := flagSet.Lookup(extraVolumeTagsFlagName)
-			if extraVolumeTagsFlag == nil {
-				t.Fatalf("expected %q flag to be added but it is not", extraVolumeTagsFlagName)
+			extraTagsFlag := flagSet.Lookup(extraTagsFlagName)
+			if extraTagsFlag == nil {
+				t.Fatalf("expected %q flag to be added but it is not", extraTagsFlagName)
 			}
-			if !reflect.DeepEqual(options.ControllerOptions.ExtraVolumeTags, extraVolumeTags) {
-				t.Fatalf("expected extra volume tags to be %q but it is %q", extraVolumeTags, options.ControllerOptions.ExtraVolumeTags)
+			if !reflect.DeepEqual(options.ControllerOptions.ExtraTags, extraTags) {
+				t.Fatalf("expected extra tags to be %q but it is %q", extraTags, options.ControllerOptions.ExtraTags)
 			}
 		}
 

--- a/pkg/cloud/cloud.go
+++ b/pkg/cloud/cloud.go
@@ -512,7 +512,9 @@ func (c *cloud) CreateSnapshot(ctx context.Context, volumeID string, snapshotOpt
 
 	var tags []*ec2.Tag
 	for key, value := range snapshotOptions.Tags {
-		tags = append(tags, &ec2.Tag{Key: &key, Value: &value})
+		copiedKey := key
+		copiedValue := value
+		tags = append(tags, &ec2.Tag{Key: &copiedKey, Value: &copiedValue})
 	}
 	tagSpec := ec2.TagSpecification{
 		ResourceType: aws.String("snapshot"),

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -54,7 +54,7 @@ type Driver struct {
 
 type DriverOptions struct {
 	endpoint            string
-	extraVolumeTags     map[string]string
+	extraTags           map[string]string
 	mode                Mode
 	volumeAttachLimit   int64
 	kubernetesClusterID string
@@ -146,9 +146,18 @@ func WithEndpoint(endpoint string) func(*DriverOptions) {
 	}
 }
 
+func WithExtraTags(extraTags map[string]string) func(*DriverOptions) {
+	return func(o *DriverOptions) {
+		o.extraTags = extraTags
+	}
+}
+
 func WithExtraVolumeTags(extraVolumeTags map[string]string) func(*DriverOptions) {
 	return func(o *DriverOptions) {
-		o.extraVolumeTags = extraVolumeTags
+		if o.extraTags == nil && extraVolumeTags != nil {
+			klog.Warning("DEPRECATION WARNING: --extra-volume-tags is deprecated, please use --extra-tags instead")
+			o.extraTags = extraVolumeTags
+		}
 	}
 }
 

--- a/pkg/driver/driver_test.go
+++ b/pkg/driver/driver_test.go
@@ -30,12 +30,32 @@ func TestWithEndpoint(t *testing.T) {
 	}
 }
 
+func TestWithExtraTags(t *testing.T) {
+	value := map[string]string{"foo": "bar"}
+	options := &DriverOptions{}
+	WithExtraTags(value)(options)
+	if !reflect.DeepEqual(options.extraTags, value) {
+		t.Fatalf("expected extraTags option got set to %+v but is set to %+v", value, options.extraTags)
+	}
+}
+
 func TestWithExtraVolumeTags(t *testing.T) {
 	value := map[string]string{"foo": "bar"}
 	options := &DriverOptions{}
 	WithExtraVolumeTags(value)(options)
-	if !reflect.DeepEqual(options.extraVolumeTags, value) {
-		t.Fatalf("expected extraVolumeTags option got set to %+v but is set to %+v", value, options.extraVolumeTags)
+	if !reflect.DeepEqual(options.extraTags, value) {
+		t.Fatalf("expected extraTags option got set to %+v but is set to %+v", value, options.extraTags)
+	}
+}
+
+func TestWithExtraVolumeTagsNoOverwrite(t *testing.T) {
+	extraTagsValue := map[string]string{"foo": "bar"}
+	options := &DriverOptions{}
+	WithExtraTags(extraTagsValue)(options)
+	extraVolumeTagsValue := map[string]string{"baz": "qux"}
+	WithExtraVolumeTags(extraVolumeTagsValue)(options)
+	if !reflect.DeepEqual(options.extraTags, extraTagsValue) {
+		t.Fatalf("expected extraTags option got set to %+v but is set to %+v", extraTagsValue, options.extraTags)
 	}
 }
 

--- a/pkg/driver/validation.go
+++ b/pkg/driver/validation.go
@@ -24,8 +24,8 @@ import (
 )
 
 func ValidateDriverOptions(options *DriverOptions) error {
-	if err := validateExtraVolumeTags(options.extraVolumeTags); err != nil {
-		return fmt.Errorf("Invalid extra volume tags: %v", err)
+	if err := validateExtraTags(options.extraTags); err != nil {
+		return fmt.Errorf("Invalid extra tags: %v", err)
 	}
 
 	if err := validateMode(options.mode); err != nil {
@@ -35,26 +35,29 @@ func ValidateDriverOptions(options *DriverOptions) error {
 	return nil
 }
 
-func validateExtraVolumeTags(tags map[string]string) error {
+func validateExtraTags(tags map[string]string) error {
 	if len(tags) > cloud.MaxNumTagsPerResource {
-		return fmt.Errorf("Too many volume tags (actual: %d, limit: %d)", len(tags), cloud.MaxNumTagsPerResource)
+		return fmt.Errorf("Too many tags (actual: %d, limit: %d)", len(tags), cloud.MaxNumTagsPerResource)
 	}
 
 	for k, v := range tags {
 		if len(k) > cloud.MaxTagKeyLength {
-			return fmt.Errorf("Volume tag key too long (actual: %d, limit: %d)", len(k), cloud.MaxTagKeyLength)
+			return fmt.Errorf("Tag key too long (actual: %d, limit: %d)", len(k), cloud.MaxTagKeyLength)
 		}
 		if len(v) > cloud.MaxTagValueLength {
-			return fmt.Errorf("Volume tag value too long (actual: %d, limit: %d)", len(v), cloud.MaxTagValueLength)
+			return fmt.Errorf("Tag value too long (actual: %d, limit: %d)", len(v), cloud.MaxTagValueLength)
 		}
 		if k == cloud.VolumeNameTagKey {
-			return fmt.Errorf("Volume tag key '%s' is reserved", cloud.VolumeNameTagKey)
+			return fmt.Errorf("Tag key '%s' is reserved", cloud.VolumeNameTagKey)
+		}
+		if k == cloud.SnapshotNameTagKey {
+			return fmt.Errorf("Tag key '%s' is reserved", cloud.VolumeNameTagKey)
 		}
 		if strings.HasPrefix(k, cloud.KubernetesTagKeyPrefix) {
-			return fmt.Errorf("Volume tag key prefix '%s' is reserved", cloud.KubernetesTagKeyPrefix)
+			return fmt.Errorf("Tag key prefix '%s' is reserved", cloud.KubernetesTagKeyPrefix)
 		}
 		if strings.HasPrefix(k, cloud.AWSTagKeyPrefix) {
-			return fmt.Errorf("Volume tag key prefix '%s' is reserved", cloud.AWSTagKeyPrefix)
+			return fmt.Errorf("Tag key prefix '%s' is reserved", cloud.AWSTagKeyPrefix)
 		}
 	}
 

--- a/pkg/driver/validation_test.go
+++ b/pkg/driver/validation_test.go
@@ -62,46 +62,46 @@ func TestValidateExtraVolumeTags(t *testing.T) {
 			tags: map[string]string{
 				randomString(cloud.MaxTagKeyLength + 1): "extra-tag-value",
 			},
-			expErr: fmt.Errorf("Volume tag key too long (actual: %d, limit: %d)", cloud.MaxTagKeyLength+1, cloud.MaxTagKeyLength),
+			expErr: fmt.Errorf("Tag key too long (actual: %d, limit: %d)", cloud.MaxTagKeyLength+1, cloud.MaxTagKeyLength),
 		},
 		{
 			name: "invalid tag: value too long",
 			tags: map[string]string{
 				"extra-tag-key": randomString(cloud.MaxTagValueLength + 1),
 			},
-			expErr: fmt.Errorf("Volume tag value too long (actual: %d, limit: %d)", cloud.MaxTagValueLength+1, cloud.MaxTagValueLength),
+			expErr: fmt.Errorf("Tag value too long (actual: %d, limit: %d)", cloud.MaxTagValueLength+1, cloud.MaxTagValueLength),
 		},
 		{
 			name: "invalid tag: reserved CSI key",
 			tags: map[string]string{
 				cloud.VolumeNameTagKey: "extra-tag-value",
 			},
-			expErr: fmt.Errorf("Volume tag key '%s' is reserved", cloud.VolumeNameTagKey),
+			expErr: fmt.Errorf("Tag key '%s' is reserved", cloud.VolumeNameTagKey),
 		},
 		{
 			name: "invalid tag: reserved Kubernetes key prefix",
 			tags: map[string]string{
 				cloud.KubernetesTagKeyPrefix + "/cluster": "extra-tag-value",
 			},
-			expErr: fmt.Errorf("Volume tag key prefix '%s' is reserved", cloud.KubernetesTagKeyPrefix),
+			expErr: fmt.Errorf("Tag key prefix '%s' is reserved", cloud.KubernetesTagKeyPrefix),
 		},
 		{
 			name: "invalid tag: reserved AWS key prefix",
 			tags: map[string]string{
 				cloud.AWSTagKeyPrefix + "foo": "extra-tag-value",
 			},
-			expErr: fmt.Errorf("Volume tag key prefix '%s' is reserved", cloud.AWSTagKeyPrefix),
+			expErr: fmt.Errorf("Tag key prefix '%s' is reserved", cloud.AWSTagKeyPrefix),
 		},
 		{
-			name:   "invalid tag: too many volume tags",
+			name:   "invalid tag: too many tags",
 			tags:   randomStringMap(cloud.MaxNumTagsPerResource + 1),
-			expErr: fmt.Errorf("Too many volume tags (actual: %d, limit: %d)", cloud.MaxNumTagsPerResource+1, cloud.MaxNumTagsPerResource),
+			expErr: fmt.Errorf("Too many tags (actual: %d, limit: %d)", cloud.MaxNumTagsPerResource+1, cloud.MaxNumTagsPerResource),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			err := validateExtraVolumeTags(tc.tags)
+			err := validateExtraTags(tc.tags)
 			if !reflect.DeepEqual(err, tc.expErr) {
 				t.Fatalf("error not equal\ngot:\n%s\nexpected:\n%s", err, tc.expErr)
 			}
@@ -170,15 +170,15 @@ func TestValidateDriverOptions(t *testing.T) {
 			extraVolumeTags: map[string]string{
 				randomString(cloud.MaxTagKeyLength + 1): "extra-tag-value",
 			},
-			expErr: fmt.Errorf("Invalid extra volume tags: Volume tag key too long (actual: %d, limit: %d)", cloud.MaxTagKeyLength+1, cloud.MaxTagKeyLength),
+			expErr: fmt.Errorf("Invalid extra tags: Tag key too long (actual: %d, limit: %d)", cloud.MaxTagKeyLength+1, cloud.MaxTagKeyLength),
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			err := ValidateDriverOptions(&DriverOptions{
-				extraVolumeTags: tc.extraVolumeTags,
-				mode:            tc.mode,
+				extraTags: tc.extraVolumeTags,
+				mode:      tc.mode,
 			})
 			if !reflect.DeepEqual(err, tc.expErr) {
 				t.Fatalf("error not equal\ngot:\n%s\nexpected:\n%s", err, tc.expErr)


### PR DESCRIPTION
This adds tags to snapshots so that they can be deleted on cluster deletion.

CC @openshift/storage 