### PR TITLE
Add BZ component to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,2 +1,4 @@
 approvers:
 - openshift-storage-maintainers
+component: "Storage"
+subcomponent: Kubernetes External Components


### PR DESCRIPTION
Add storage component to OWNERS, so ART automation knows where to report bugs. It got lost during the last rebase.