### PR TITLE
Bug 2050173: Fix build on ARM after rebase

### DIFF
--- a/Dockerfile.openshift
+++ b/Dockerfile.openshift
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 COPY . .
-RUN make
+RUN make ARCH=$(go env GOARCH)
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 # Get mkfs & blkid

--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,7 +1,7 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 COPY . .
-RUN make
+RUN make ARCH=$(go env GOARCH)
 
 FROM registry.ci.openshift.org/ocp/4.11:base
 # Get mkfs & blkid


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/type bug

**What is this PR about? / Why do we need it?**
﻿The Makefile now defines ARCH?=amd64 which is used to define GOARCH,
which breaks the builds on other arches (namely arm64, given this is for
AWS).

Without this, 4.10 and 4.11 CI on AWS turned solid red.
