### PR TITLE
STOR-1019: Pin k8s.io/dynamic-resource-allocation to v0.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -124,6 +124,7 @@ replace (
 	k8s.io/controller-manager => k8s.io/controller-manager v0.26.0
 	k8s.io/cri-api => k8s.io/cri-api v0.26.0
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.0
+	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.0 // Fix "go: k8s.io/dynamic-resource-allocation@v0.0.0: invalid version: unknown revision v0.0.0"
 	k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.0
 	k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.0
 	k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.0

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1194,6 +1194,7 @@ sigs.k8s.io/yaml
 # k8s.io/controller-manager => k8s.io/controller-manager v0.26.0
 # k8s.io/cri-api => k8s.io/cri-api v0.26.0
 # k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.26.0
+# k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.26.0
 # k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.26.0
 # k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.26.0
 # k8s.io/kube-proxy => k8s.io/kube-proxy v0.26.0


### PR DESCRIPTION
This is intended to fix the following error:

```
$ go list -mod readonly -m all
go: k8s.io/dynamic-resource-allocation@v0.0.0: invalid version: unknown revision v0.0.0
```

CC @openshift/storage 