### PR TITLE
OCPBUGS-12932: 4.11: Bump golang.org/x/text

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,7 @@ require (
 	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d // indirect
 	golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d // indirect
-	golang.org/x/text v0.3.6 // indirect
+	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba // indirect
 	google.golang.org/appengine v1.6.5 // indirect
 	google.golang.org/genproto v0.0.0-20201110150050-8816d57aaa9a // indirect

--- a/go.sum
+++ b/go.sum
@@ -772,8 +772,9 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/text v0.3.6 h1:aRYxNxv6iGQlyVaZmk6ZgYEDa+Jg18DxebPSrd6bg1M=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
+golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/vendor/golang.org/x/text/internal/language/language.go
+++ b/vendor/golang.org/x/text/internal/language/language.go
@@ -251,6 +251,13 @@ func (t Tag) Parent() Tag {
 
 // ParseExtension parses s as an extension and returns it on success.
 func ParseExtension(s string) (ext string, err error) {
+	defer func() {
+		if recover() != nil {
+			ext = ""
+			err = ErrSyntax
+		}
+	}()
+
 	scan := makeScannerString(s)
 	var end int
 	if n := len(scan.token); n != 1 {
@@ -461,7 +468,14 @@ func (t Tag) findTypeForKey(key string) (start, sep, end int, hasExt bool) {
 // ParseBase parses a 2- or 3-letter ISO 639 code.
 // It returns a ValueError if s is a well-formed but unknown language identifier
 // or another error if another error occurred.
-func ParseBase(s string) (Language, error) {
+func ParseBase(s string) (l Language, err error) {
+	defer func() {
+		if recover() != nil {
+			l = 0
+			err = ErrSyntax
+		}
+	}()
+
 	if n := len(s); n < 2 || 3 < n {
 		return 0, ErrSyntax
 	}
@@ -472,7 +486,14 @@ func ParseBase(s string) (Language, error) {
 // ParseScript parses a 4-letter ISO 15924 code.
 // It returns a ValueError if s is a well-formed but unknown script identifier
 // or another error if another error occurred.
-func ParseScript(s string) (Script, error) {
+func ParseScript(s string) (scr Script, err error) {
+	defer func() {
+		if recover() != nil {
+			scr = 0
+			err = ErrSyntax
+		}
+	}()
+
 	if len(s) != 4 {
 		return 0, ErrSyntax
 	}
@@ -489,7 +510,14 @@ func EncodeM49(r int) (Region, error) {
 // ParseRegion parses a 2- or 3-letter ISO 3166-1 or a UN M.49 code.
 // It returns a ValueError if s is a well-formed but unknown region identifier
 // or another error if another error occurred.
-func ParseRegion(s string) (Region, error) {
+func ParseRegion(s string) (r Region, err error) {
+	defer func() {
+		if recover() != nil {
+			r = 0
+			err = ErrSyntax
+		}
+	}()
+
 	if n := len(s); n < 2 || 3 < n {
 		return 0, ErrSyntax
 	}
@@ -578,7 +606,14 @@ type Variant struct {
 
 // ParseVariant parses and returns a Variant. An error is returned if s is not
 // a valid variant.
-func ParseVariant(s string) (Variant, error) {
+func ParseVariant(s string) (v Variant, err error) {
+	defer func() {
+		if recover() != nil {
+			v = Variant{}
+			err = ErrSyntax
+		}
+	}()
+
 	s = strings.ToLower(s)
 	if id, ok := variantIndex[s]; ok {
 		return Variant{id, s}, nil

--- a/vendor/golang.org/x/text/internal/language/parse.go
+++ b/vendor/golang.org/x/text/internal/language/parse.go
@@ -232,6 +232,13 @@ func Parse(s string) (t Tag, err error) {
 	if s == "" {
 		return Und, ErrSyntax
 	}
+	defer func() {
+		if recover() != nil {
+			t = Und
+			err = ErrSyntax
+			return
+		}
+	}()
 	if len(s) <= maxAltTaglen {
 		b := [maxAltTaglen]byte{}
 		for i, c := range s {

--- a/vendor/golang.org/x/text/language/parse.go
+++ b/vendor/golang.org/x/text/language/parse.go
@@ -43,6 +43,13 @@ func Parse(s string) (t Tag, err error) {
 // https://www.unicode.org/reports/tr35/#Unicode_Language_and_Locale_Identifiers.
 // The resulting tag is canonicalized using the canonicalization type c.
 func (c CanonType) Parse(s string) (t Tag, err error) {
+	defer func() {
+		if recover() != nil {
+			t = Tag{}
+			err = language.ErrSyntax
+		}
+	}()
+
 	tt, err := language.Parse(s)
 	if err != nil {
 		return makeTag(tt), err
@@ -79,6 +86,13 @@ func Compose(part ...interface{}) (t Tag, err error) {
 // tag is returned after canonicalizing using CanonType c. If one or more errors
 // are encountered, one of the errors is returned.
 func (c CanonType) Compose(part ...interface{}) (t Tag, err error) {
+	defer func() {
+		if recover() != nil {
+			t = Tag{}
+			err = language.ErrSyntax
+		}
+	}()
+
 	var b language.Builder
 	if err = update(&b, part...); err != nil {
 		return und, err
@@ -142,6 +156,14 @@ var errInvalidWeight = errors.New("ParseAcceptLanguage: invalid weight")
 // Tags with a weight of zero will be dropped. An error will be returned if the
 // input could not be parsed.
 func ParseAcceptLanguage(s string) (tag []Tag, q []float32, err error) {
+	defer func() {
+		if recover() != nil {
+			tag = nil
+			q = nil
+			err = language.ErrSyntax
+		}
+	}()
+
 	var entry string
 	for s != "" {
 		if entry, s = split(s, ','); entry == "" {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -298,8 +298,8 @@ golang.org/x/sys/windows
 # golang.org/x/term v0.0.0-20210220032956-6a3ed077a48d
 ## explicit; go 1.11
 golang.org/x/term
-# golang.org/x/text v0.3.6
-## explicit; go 1.11
+# golang.org/x/text v0.3.7
+## explicit; go 1.17
 golang.org/x/text/encoding
 golang.org/x/text/encoding/charmap
 golang.org/x/text/encoding/htmlindex


### PR DESCRIPTION
To fix CVE-2021-38561. This fix was merged upstream as part of commit cee57ef595a25b23f8068058fd93f52e2ca63f82, "Update driver dependencies" and we got it to 4.12 as part of rebase.

@openshift/storage 