### PR TITLE
OCPBUGS-16783: Chore: Update OWNERS and OWNERS_ALIASES

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,3 +1,3 @@
 approvers:
 - openshift-storage-maintainers
-component: "Storage"
+component: "Storage / Kubernetes External Components"

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -5,4 +5,5 @@ aliases:
     - gnufied
     - bertinatto
     - dobsonj
-
+    - RomanBednar
+    - mpatlasov


### PR DESCRIPTION
Changing the component as per the other Storage repos and adding Roman and Maxim in storage maintainers.