### PR TITLE
OCPBUGS-45562: Updating ose-aws-ebs-csi-driver-container image to be consistent with ART for 4.19

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -15,4 +15,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.22-openshift-4.18
+  tag: rhel-9-release-golang-1.23-openshift-4.19

--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.22-openshift-4.18 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 COPY . .
 RUN make ARCH=$(go env GOARCH)
 
-FROM registry.ci.openshift.org/ocp/4.18:base-rhel9
+FROM registry.ci.openshift.org/ocp/4.19:base-rhel9
 # Get mkfs & blkid
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux && \


### PR DESCRIPTION
This is https://github.com/openshift/aws-ebs-csi-driver/pull/279 from the ART bot + `make update` to add the header back to `.ci-operator.yaml` to get past the verify failure.

/cc @openshift/storage
