### PR TITLE
ART-12521: update go mod dependency for konflux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ coverage.html
 
 # Vagrant
 .vagrant
-Vagrantfile
 
 # vim
 *.swp

--- a/vendor/github.com/mistifyio/go-zfs/Vagrantfile
+++ b/vendor/github.com/mistifyio/go-zfs/Vagrantfile
@@ -1,0 +1,34 @@
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+    config.vm.box = "ubuntu/trusty64"
+	config.ssh.forward_agent = true
+
+	config.vm.synced_folder ".", "/home/vagrant/go/src/github.com/mistifyio/go-zfs", create: true
+
+    config.vm.provision "shell", inline: <<EOF
+cat << END > /etc/profile.d/go.sh
+export GOPATH=\\$HOME/go
+export PATH=\\$GOPATH/bin:/usr/local/go/bin:\\$PATH
+END
+
+chown -R vagrant /home/vagrant/go
+
+apt-get update
+apt-get install -y software-properties-common curl
+apt-add-repository --yes ppa:zfs-native/stable
+apt-get update
+apt-get install -y ubuntu-zfs
+
+cd /home/vagrant
+curl -z go1.3.3.linux-amd64.tar.gz -L -O https://storage.googleapis.com/golang/go1.3.3.linux-amd64.tar.gz
+tar -C /usr/local -zxf /home/vagrant/go1.3.3.linux-amd64.tar.gz
+
+cat << END > /etc/sudoers.d/go
+Defaults env_keep += "GOPATH"
+END
+
+EOF
+
+end


### PR DESCRIPTION
Image build was failing on Konflux due to missing go mod dependencies.

```
2025-04-04 17:29:48,104 ERROR vendor directory changed after vendoring:
A	vendor/github.com/mistifyio/go-zfs/Vagrantfile
2025-04-04 17:29:53,334 ERROR PackageRejected: The content of the vendor directory is not consistent with go.mod. 
```

Konflux ignores .gitignore files since its a possible security gap. 