### PR TITLE
OCPBUGS-86167: UPSTREAM: 2367: cleanup: `make verify` should ignore copyright year

### DIFF
--- a/hack/verify-update.sh
+++ b/hack/verify-update.sh
@@ -30,7 +30,9 @@ if ! make -C "${TEST_DIR}" update >/dev/null; then
   exit 1
 fi
 
-if ! diff -x bin -r "${TEST_DIR}" "${ROOT}"; then
+# Ignore copyright year changes
+COPYRIGHT_REGEX="Copyright [0-9]\{4\} The Kubernetes Authors.$"
+if ! diff -x bin -I "${COPYRIGHT_REGEX}" -r "${TEST_DIR}" "${ROOT}"; then
   echo "Auto-generation/formatting needs to run!"
   echo "Run \`make update\` to fix!"
   exit 1


### PR DESCRIPTION
Cherry-pick of commit 6e83fd2796b1a78813f1294e43f74d49419ee269 from release-4.19