### PR TITLE
OCPBUGS-87394: bump golang to 1.26 and golint to v2.12.2

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 COPY . .
 RUN make ARCH=$(go env GOARCH)
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 # Get mkfs & blkid
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux && \

--- a/hack/tools/install.sh
+++ b/hack/tools/install.sh
@@ -27,7 +27,7 @@ EKSCTL_VERSION="v0.212.0"
 # https://github.com/onsi/ginkgo
 GINKGO_VERSION="v2.24.0"
 # https://github.com/golangci/golangci-lint
-GOLANGCI_LINT_VERSION="v2.4.0"
+GOLANGCI_LINT_VERSION="v2.12.2"
 # https://github.com/hairyhenderson/gomplate
 GOMPLATE_VERSION="v4.3.3"
 # https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build base images to support newer runtime environments.
  * Upgraded build tooling to the latest compatible versions for improved build performance and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->