### PR TITLE
OCPBUGS-87394: UPSTREAM: <carry>: Updating ose-aws-ebs-csi-driver-container image

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: rhel-9-release-golang-1.25-openshift-4.22
+  tag: rhel-9-release-golang-1.26-openshift-5.0

--- a/Dockerfile.openshift.rhel7
+++ b/Dockerfile.openshift.rhel7
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.22 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.26-openshift-5.0 AS builder
 WORKDIR /go/src/github.com/kubernetes-sigs/aws-ebs-csi-driver
 COPY . .
 RUN make ARCH=$(go env GOARCH)
 
-FROM registry.ci.openshift.org/ocp/4.22:base-rhel9
+FROM registry.ci.openshift.org/ocp/5.0:base-rhel9
 # Get mkfs & blkid
 RUN yum update -y && \
     yum install --setopt=tsflags=nodocs -y e2fsprogs xfsprogs util-linux && \

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,8 @@ update: update/gofix update/gofmt update/kustomize update/mockgen update/gomod u
 	@echo "All updates succeeded!"
 
 .PHONY: verify
-verify: verify/govet verify/golangci-lint verify/update
+# OpenShift carry: do not run golint, it frequently fails when ART bumps go
+verify: verify/govet verify/update
 	@echo "All verifications passed!"
 
 .PHONY: cluster/create

--- a/cmd/hooks/prestop.go
+++ b/cmd/hooks/prestop.go
@@ -104,7 +104,7 @@ func waitForVolumeAttachments(clientset kubernetes.Interface, nodeName string) e
 	informer := factory.Storage().V1().VolumeAttachments().Informer()
 
 	_, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		DeleteFunc: func(obj interface{}) {
+		DeleteFunc: func(obj any) {
 			klog.V(5).InfoS("DeleteFunc: VolumeAttachment deleted", "node", nodeName)
 			va, ok := obj.(*storagev1.VolumeAttachment)
 			if !ok {
@@ -116,7 +116,7 @@ func waitForVolumeAttachments(clientset kubernetes.Interface, nodeName string) e
 				}
 			}
 		},
-		UpdateFunc: func(oldObj, newObj interface{}) {
+		UpdateFunc: func(oldObj, newObj any) {
 			klog.V(5).InfoS("UpdateFunc: VolumeAttachment updated", "node", nodeName)
 			va, ok := newObj.(*storagev1.VolumeAttachment)
 			if !ok {

--- a/cmd/hooks/prestop_test.go
+++ b/cmd/hooks/prestop_test.go
@@ -180,7 +180,7 @@ func TestPreStopHook(t *testing.T) {
 				mockStorageV1Interface.EXPECT().VolumeAttachments().Return(mockVolumeAttachments).AnyTimes()
 				gomock.InOrder(
 					mockVolumeAttachments.EXPECT().List(gomock.Any(), gomock.Any()).Return(fakeVolumeAttachments, nil).AnyTimes(),
-					mockVolumeAttachments.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(func(signal, watchSignal interface{}) (watch.Interface, error) {
+					mockVolumeAttachments.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(func(signal, watchSignal any) (watch.Interface, error) {
 						deleteSignal <- true
 						return fakeWatcher, nil
 					}).AnyTimes(),
@@ -306,7 +306,7 @@ func TestPreStopHook(t *testing.T) {
 				mockStorageV1Interface.EXPECT().VolumeAttachments().Return(mockVolumeAttachments).AnyTimes()
 				gomock.InOrder(
 					mockVolumeAttachments.EXPECT().List(gomock.Any(), gomock.Any()).Return(fakeVolumeAttachments, nil).AnyTimes(),
-					mockVolumeAttachments.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(func(signal, watchSignal interface{}) (watch.Interface, error) {
+					mockVolumeAttachments.EXPECT().Watch(gomock.Any(), gomock.Any()).DoAndReturn(func(signal, watchSignal any) (watch.Interface, error) {
 						deleteSignal <- true
 						return fakeWatcher, nil
 					}).AnyTimes(),

--- a/pkg/batcher/batcher.go
+++ b/pkg/batcher/batcher.go
@@ -50,7 +50,7 @@ import (
 // waits for a defined duration (maxDelay) before triggering a batch execution. The actual task execution
 // logic is provided by the execFunc, which processes tasks and returns their corresponding results. Tasks are
 // queued via the taskChan and stored in pendingTasks until batch execution.
-type Batcher[InputType comparable, ResultType interface{}] struct {
+type Batcher[InputType comparable, ResultType any] struct {
 	// execFunc is the function responsible for executing a batch of tasks.
 	// It returns a map associating each task with its result.
 	execFunc func(inputs []InputType) (map[InputType]ResultType, error)
@@ -72,14 +72,14 @@ type Batcher[InputType comparable, ResultType interface{}] struct {
 
 // BatchResult encapsulates the response of a batched task.
 // A task will either have a result or an error, but not both.
-type BatchResult[ResultType interface{}] struct {
+type BatchResult[ResultType any] struct {
 	Result ResultType
 	Err    error
 }
 
 // taskEntry represents a single task waiting to be batched and its associated result channel.
 // The result channel is used to communicate the task's result back to the caller.
-type taskEntry[InputType comparable, ResultType interface{}] struct {
+type taskEntry[InputType comparable, ResultType any] struct {
 	task       InputType
 	resultChan chan BatchResult[ResultType]
 }
@@ -87,7 +87,7 @@ type taskEntry[InputType comparable, ResultType interface{}] struct {
 // New creates and returns a Batcher configured with the specified maxEntries and maxDelay parameters.
 // Upon instantiation, it immediately launches the internal task manager as a goroutine to oversee batch operations.
 // The provided execFunc is used to execute batch requests.
-func New[InputType comparable, ResultType interface{}](entries int, delay time.Duration, fn func(inputs []InputType) (map[InputType]ResultType, error)) *Batcher[InputType, ResultType] {
+func New[InputType comparable, ResultType any](entries int, delay time.Duration, fn func(inputs []InputType) (map[InputType]ResultType, error)) *Batcher[InputType, ResultType] {
 	klog.V(7).InfoS("New: initializing Batcher", "maxEntries", entries, "maxDelay", delay)
 
 	b := &Batcher[InputType, ResultType]{

--- a/pkg/cloud/devicemanager/allocator.go
+++ b/pkg/cloud/devicemanager/allocator.go
@@ -57,7 +57,7 @@ func (d *nameAllocator) GetNext(existingNames ExistingNames, likelyBadNames *syn
 	}
 
 	finalResortName := ""
-	likelyBadNames.Range(func(name, _ interface{}) bool {
+	likelyBadNames.Range(func(name, _ any) bool {
 		if name, ok := name.(string); ok {
 			if _, existing := existingNames[name]; !existing {
 				finalResortName = name

--- a/pkg/cloud/devicemanager/manager.go
+++ b/pkg/cloud/devicemanager/manager.go
@@ -19,6 +19,7 @@ package devicemanager
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -203,9 +204,7 @@ func (d *deviceManager) getDeviceNamesInUse(instance *types.Instance) map[string
 		inUse[name] = aws.ToString(blockDevice.Ebs.VolumeId)
 	}
 
-	for name, volumeID := range d.inFlight.GetNames(nodeID) {
-		inUse[name] = volumeID
-	}
+	maps.Copy(inUse, d.inFlight.GetNames(nodeID))
 
 	return inUse
 }

--- a/pkg/cloud/metadata/k8s.go
+++ b/pkg/cloud/metadata/k8s.go
@@ -129,9 +129,9 @@ func KubernetesAPIInstanceInfo(clientset kubernetes.Interface) (*Metadata, error
 
 	var instanceType string
 	if val, ok := node.GetLabels()[corev1.LabelInstanceTypeStable]; ok {
-		if strings.HasPrefix(val, "ml.") {
+		if after, ok0 := strings.CutPrefix(val, "ml."); ok0 {
 			// sagemaker instance type has 'ml.' prefix, remove 'ml.' prefix
-			instanceType = strings.TrimPrefix(val, "ml.")
+			instanceType = after
 		} else {
 			instanceType = val
 		}

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -265,9 +266,7 @@ func (d *ControllerService) CreateVolume(ctx context.Context, req *csi.CreateVol
 		return nil, status.Errorf(codes.InvalidArgument, "Invalid tag value: %v", err)
 	}
 
-	for k, v := range addTags {
-		volumeTags[k] = v
-	}
+	maps.Copy(volumeTags, addTags)
 
 	responseCtx := map[string]string{}
 
@@ -786,13 +785,9 @@ func (d *ControllerService) CreateSnapshot(ctx context.Context, req *csi.CreateS
 		snapshotTags[resourceLifecycleTag] = ResourceLifecycleOwned
 		snapshotTags[NameTag] = d.options.KubernetesClusterID + "-dynamic-" + snapshotName
 	}
-	for k, v := range d.options.ExtraTags {
-		snapshotTags[k] = v
-	}
+	maps.Copy(snapshotTags, d.options.ExtraTags)
 
-	for k, v := range addTags {
-		snapshotTags[k] = v
-	}
+	maps.Copy(snapshotTags, addTags)
 
 	opts := &cloud.SnapshotOptions{
 		Tags:       snapshotTags,

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -107,7 +107,7 @@ func (d *Driver) Run() error {
 		return err
 	}
 
-	logErr := func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
+	logErr := func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
 		resp, err := handler(ctx, req)
 		if err != nil {
 			klog.ErrorS(err, "GRPC error")

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -23,6 +23,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -824,12 +825,7 @@ func (d *NodeService) getVolumesLimit() int64 {
 // slice already contains a mount option. This is used to prevent
 // passing duplicate option to the mount command.
 func hasMountOption(options []string, opt string) bool {
-	for _, o := range options {
-		if o == opt {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(options, opt)
 }
 
 // collectMountOptions returns array of mount options from
@@ -914,12 +910,12 @@ func startNotReadyTaintWatcher(clientset kubernetes.Interface, maxWatchDuration 
 	}
 
 	if _, err := informer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		AddFunc: func(obj interface{}) {
+		AddFunc: func(obj any) {
 			if n, ok := obj.(*corev1.Node); ok {
 				attemptTaintRemoval(n)
 			}
 		},
-		UpdateFunc: func(_, newObj interface{}) {
+		UpdateFunc: func(_, newObj any) {
 			if n, ok := newObj.(*corev1.Node); ok {
 				attemptTaintRemoval(n)
 			}
@@ -964,9 +960,9 @@ func hasNotReadyTaint(n *corev1.Node) bool {
 
 // Struct for JSON patch operations.
 type JSONPatch struct {
-	OP    string      `json:"op,omitempty"`
-	Path  string      `json:"path,omitempty"`
-	Value interface{} `json:"value"`
+	OP    string `json:"op,omitempty"`
+	Path  string `json:"path,omitempty"`
+	Value any    `json:"value"`
 }
 
 // removeNotReadyTaint removes the taint ebs.csi.aws.com/agent-not-ready from the local node

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -53,7 +53,7 @@ var (
 
 type metricRecorder struct {
 	registry        *prometheus.Registry
-	metrics         map[string]interface{}
+	metrics         map[string]any
 	asyncEC2Metrics *AsyncEC2Collector
 }
 
@@ -68,7 +68,7 @@ func InitializeRecorder(deprecatedMetrics bool) *metricRecorder {
 	once.Do(func() {
 		r = &metricRecorder{
 			registry: prometheus.NewRegistry(),
-			metrics:  make(map[string]interface{}),
+			metrics:  make(map[string]any),
 		}
 	})
 	return r

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -92,8 +92,8 @@ test_re_register_total{key="value2"} 1
 }
 
 func getMetricNameFromExpected(expected string) string {
-	lines := strings.Split(expected, "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(expected, "\n")
+	for line := range lines {
 		if strings.Contains(line, "{") {
 			return strings.Split(line, "{")[0]
 		}

--- a/pkg/metrics/nvme.go
+++ b/pkg/metrics/nvme.go
@@ -355,8 +355,8 @@ func getCSIManagedDevices(path string) ([]string, error) {
 		return nil, fmt.Errorf("getCSIManagedDevices: error reading mountinfo: %w", err)
 	}
 
-	lines := strings.Split(string(mountinfo), "\n")
-	for _, line := range lines {
+	lines := strings.SplitSeq(string(mountinfo), "\n")
+	for line := range lines {
 		fields := strings.Fields(line)
 
 		// https://man7.org/linux/man-pages/man5/proc.5.html

--- a/pkg/util/template/funcs.go
+++ b/pkg/util/template/funcs.go
@@ -22,19 +22,19 @@ import (
 )
 
 // Disable functions.
-func html(...interface{}) (string, error) {
+func html(...any) (string, error) {
 	return "", errors.New("cannot call 'html' function")
 }
 
-func js(...interface{}) (string, error) {
+func js(...any) (string, error) {
 	return "", errors.New("cannot call 'js' function")
 }
 
-func call(...interface{}) (string, error) {
+func call(...any) (string, error) {
 	return "", errors.New("cannot call 'call' function")
 }
 
-func urlquery(...interface{}) (string, error) {
+func urlquery(...any) (string, error) {
 	return "", errors.New("cannot call 'urlquery' function")
 }
 

--- a/pkg/util/template/template.go
+++ b/pkg/util/template/template.go
@@ -34,7 +34,7 @@ type VolumeSnapshotProps struct {
 	VolumeSnapshotContentName string
 }
 
-func Evaluate(tm []string, props interface{}, warnOnly bool) (map[string]string, error) {
+func Evaluate(tm []string, props any, warnOnly bool) (map[string]string, error) {
 	md := make(map[string]string)
 	for _, s := range tm {
 		st := strings.SplitN(s, "=", 2)
@@ -59,7 +59,7 @@ func Evaluate(tm []string, props interface{}, warnOnly bool) (map[string]string,
 	return md, nil
 }
 
-func execTemplate(value string, props interface{}, t *template.Template) (string, error) {
+func execTemplate(value string, props any, t *template.Template) (string, error) {
 	tmpl, err := t.Parse(value)
 	if err != nil {
 		return "", err

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -156,7 +156,7 @@ func NormalizeWindowsPath(path string) string {
 
 // SanitizeRequest takes a request object and returns a copy of the request with
 // the "Secrets" field cleared.
-func SanitizeRequest(req interface{}) interface{} {
+func SanitizeRequest(req any) any {
 	v := reflect.ValueOf(&req).Elem()
 	e := reflect.New(v.Elem().Type()).Elem()
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -231,8 +231,8 @@ type TestRequest struct {
 func TestSanitizeRequest(t *testing.T) {
 	tests := []struct {
 		name     string
-		req      interface{}
-		expected interface{}
+		req      any
+		expected any
 	}{
 		{
 			name: "Request with Secrets",


### PR DESCRIPTION
Temporarily disable golangci-lint verification, as golangci-lint v2.4.0 is incompatible with go1.26, and the current codebase state is incompatible with golangci-lint v2.12.2. Will be re-enabled after the next upstream rebase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined the automated verification workflow by removing an extra linting step while keeping remaining checks and update verification.
  * Updated CI configuration and OpenShift/RHEL build bases to target newer Go and OpenShift releases, improving alignment with the current platform build environment.  
* **Maintenance**
  * Modernized internal Go typings and utility behavior for consistency and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->